### PR TITLE
Fix issue on use_selinux function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to changes made in each version of the selinux_policy cookbook
 
 ## Unreleased
 
+- Fix issue on use_selinux function
+
 ## [2.3.5] - 2019-02-15
 
 - Fix resource failure in permissive.rb Caused by [#96](https://github.com/sous-chefs/selinux_policy/pull/96)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -15,7 +15,7 @@ class Chef
         end
 
         # return false only when SELinux is disabled and it's allowed
-        return_val = !selinux_disabled || (selinux_disabled && allow_disabled)
+        return_val = !selinux_disabled || !(selinux_disabled && allow_disabled)
         Chef::Log.warn('SELinux is disabled / unreachable, skipping') unless return_val
         return_val
       end


### PR DESCRIPTION
use_selinux returns true even when selinux is disabled.

`return_val = !selinux_disabled || (selinux_disabled && allow_disabled)`

- if selinux is enabled then it returns true. That's ok. 
- If selinux is disabled and it is not allowed, it returns false but it should be true.
- If selinux is disabled and it is allowed, it returns true but it should be false.

So it should be:

`return_val = !selinux_disabled || !(selinux_disabled && allow_disabled)`